### PR TITLE
Add additional install.sh parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PlanetScale Workflow Helper scripts 
+# PlanetScale Workflow Helper scripts
 
 This is a collection of GitHub Workflows and CI/CD helper scripts around [PlanetScale's database branching workflows](https://planetscale.com/docs/concepts/branching) to:
 * [attach, create, update, approve, merge and delete](#issue-ops-based-workflows) PlanetScale branches and deploy requests directly from your Pull Requests
@@ -18,6 +18,10 @@ To test out the IssueOps commands and helper scripts, either work on a [copy of 
 curl https://raw.githubusercontent.com/planetscale/pscale-workflow-helper-scripts/main/install.sh | bash
 ```
 
+This will download and install the latest release of the package to your repository. Alternatively, you may download the `install.sh` script and run it manually with the following parameters for additional flexibility:
+
+- `-t {RELEASE_TAG}` &mdash; This allows you to provide the specific release version tag to download and install.
+- `-s` &mdash; Providing this switch will still install the helpers scripts into the `.pscale` directory of the repository, but skip installing the default workflows provided for IssueOps commands. This is helpful if you wish to use the scripts to build custom workflows.
 
 ## Issue-Ops based workflows
 
@@ -66,7 +70,7 @@ Stay tuned for updates and any feedbacks / PRs are welcome 😊
 
 ## Zero-setup Action workflows included :sparkles:
 
-In case you like to see those helper scripts in action without any further manual configuration, just 
+In case you like to see those helper scripts in action without any further manual configuration, just
 
 1. [Create a copy of this repo](https://github.com/planetscale/pscale-cli-helper-scripts/generate) by clicking on the green 'Use this template' button or just [here](https://github.com/planetscale/pscale-cli-helper-scripts/generate). Both private and public repo visibility work.
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-RELEASE_VERSION=0.6
+if [ -n "$1" ];then
+  RELEASE_VERSION=$1
+else
+  RELEASE_VERSION=0.6
+fi
+
+if [ "true" == "$2" ];then
+  SKIP_ISSUEOPS="true"
+fi
+
+echo "SKIP_ISSUEOPS=${SKIP_ISSUEOPS}, 2nd param=$2"
+
 PSCALE_CLI_HELPER_SCRIPTS_NAME=pscale-workflow-helper-scripts
 PSCALE_SCRIPTS_DIR=.pscale/
 
-curl -L -o ${PSCALE_CLI_HELPER_SCRIPTS_NAME}.zip https://github.com/planetscale/pscale-cli-helper-scripts/archive/refs/tags/${RELEASE_VERSION}.zip
+curl -L -o ${PSCALE_CLI_HELPER_SCRIPTS_NAME}.zip https://github.com/planetscale/pscale-workflow-helper-scripts/archive/refs/tags/${RELEASE_VERSION}.zip
 unzip -o ${PSCALE_CLI_HELPER_SCRIPTS_NAME}.zip
 
 # create .pscale directory
@@ -13,11 +24,13 @@ mkdir -p ${PSCALE_SCRIPTS_DIR}
 # copy scripts to .pscale directory
 cp -r ${PSCALE_CLI_HELPER_SCRIPTS_NAME}-${RELEASE_VERSION}/.pscale/cli-helper-scripts ${PSCALE_SCRIPTS_DIR}/
 
-# create .github/workflows directory
-mkdir -p .github/workflows
+if [ "true" != "${SKIP_ISSUEOPS}" ];then
+  # create .github/workflows directory
+  mkdir -p .github/workflows
 
-# copy workflow to .github/workflows directory
-cp ${PSCALE_CLI_HELPER_SCRIPTS_NAME}-${RELEASE_VERSION}/.github/workflows/*.yml .github/workflows/
+  # copy workflow to .github/workflows directory
+  cp ${PSCALE_CLI_HELPER_SCRIPTS_NAME}-${RELEASE_VERSION}/.github/workflows/*.yml .github/workflows/
+fi
 
 # remove zip file and extracted directory
 rm ${PSCALE_CLI_HELPER_SCRIPTS_NAME}.zip
@@ -26,8 +39,11 @@ rm -rf ${PSCALE_CLI_HELPER_SCRIPTS_NAME}-${RELEASE_VERSION}
 echo
 echo "Successfully installed pscale-workflow-helper-scripts"
 echo
-echo "Please run 'git add .pscale .github/workflows' and commit changes using 'git commit -m \"Add pscale helper scripts and IssueOps workflows\"'"
-echo "Then run 'git push' to push changes"
+
+if [ "true" != "${SKIP_ISSUEOPS}" ];then
+  echo "Please run 'git add .pscale .github/workflows' and commit changes using 'git commit -m \"Add pscale helper scripts and IssueOps workflows\"'"
+  echo "Then run 'git push' to push changes"
+fi
 
 
 

--- a/install.sh
+++ b/install.sh
@@ -25,10 +25,6 @@ else
   fi
 fi
 
-if [ "true" == "$2" ];then
-  SKIP_ISSUEOPS="true"
-fi
-
 PSCALE_CLI_HELPER_SCRIPTS_NAME=pscale-workflow-helper-scripts
 PSCALE_SCRIPTS_DIR=.pscale/
 


### PR DESCRIPTION
The following parameters were added to the `install.sh` file:

- `-t {RELEASE_TAG}` - allows the user to provide a release tag to install a specific version.
- `-s` - skips installing the default workflows, but still installs the helper scripts.

Readme has been updated accordingly. A new release (0.7) will be created upon merge.